### PR TITLE
[ADD] demo data

### DIFF
--- a/l10n_fr_einvoicing/__manifest__.py
+++ b/l10n_fr_einvoicing/__manifest__.py
@@ -34,5 +34,6 @@
         "views/fr_einvoicing_log.xml",
         "views/onboarding_templates.xml",
     ],
+    "demo": ["demo/partner_demo.xml"],
     "installable": True,
 }

--- a/l10n_fr_einvoicing/demo/partner_demo.xml
+++ b/l10n_fr_einvoicing/demo/partner_demo.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright 2026 Le Filament (https://le-filament.com)
+  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<!-- oca-hooks:disable=xml-duplicate-record-id -->
+<odoo noupdate="1">
+    <record id="base.partner_demo_company_fr" model="res.partner">
+        <field name="name">Tricatel</field>
+        <field name="is_company" eval="True" />
+        <field name="street">Avenue de la République</field>
+        <field name="zip">37170</field>
+        <field name="city">Chambray-lès-Tours</field>
+        <field name="country_id" ref="base.fr" />
+        <field name="fr_directory_name">Tricatel</field>
+        <field name="fr_directory_entity_type">private</field>
+        <field name="fr_directory_siren">000000001</field>
+        <field
+            name="fr_directory_last_sync_date"
+            eval="DateTime.now() - relativedelta(days=1)"
+        />
+        <field name="fr_directory_line_ids">
+            <record
+                id="demo_tricatel_directory_line1"
+                model="fr.directory.line"
+                forcecreate="1"
+            >
+                <field name="identifier">315143296_393</field>
+                <field name="type">suffix</field>
+                <field name="siren">315143296</field>
+                <field name="suffix">393</field>
+                <field name="state">active</field>
+            </record>
+            <record
+                id="demo_tricatel_directory_line2"
+                model="fr.directory.line"
+                forcecreate="1"
+            >
+                <field name="identifier">315143296_393_test</field>
+                <field name="type">suffix</field>
+                <field name="siren">315143296</field>
+                <field name="suffix">393_test</field>
+                <field name="state">active</field>
+            </record>
+        </field>
+    </record>
+    <record id="base.partner_demo_company_fr" model="res.partner">
+        <field
+            name="default_fr_directory_line_id"
+            ref="demo_tricatel_directory_line1"
+        />
+    </record>
+    <record id="partner_demo_burger_queen" model="res.partner" forcecreate="1">
+        <field name="name">Burger Queen</field>
+        <field name="is_company" eval="True" />
+        <field name="street">809 avenue du Languedoc</field>
+        <field name="zip">12100</field>
+        <field name="city">Millau</field>
+        <field name="country_id" ref="base.fr" />
+        <field name="siren">892350455</field>
+        <field name="vat">FR23334175221</field>
+        <field name="fr_directory_name">Burger Queen</field>
+        <field name="fr_directory_entity_type">private</field>
+        <field name="fr_directory_siren">000000002</field>
+        <field
+            name="fr_directory_last_sync_date"
+            eval="DateTime.now() - relativedelta(days=1)"
+        />
+        <field name="fr_directory_line_ids">
+            <record
+                id="demo_burger_queen_directory_line1"
+                model="fr.directory.line"
+                forcecreate="1"
+            >
+                <field name="identifier">315143296_394</field>
+                <field name="type">suffix</field>
+                <field name="siren">315143296</field>
+                <field name="suffix">394</field>
+                <field name="state">active</field>
+            </record>
+        </field>
+    </record>
+    <record id="partner_demo_burger_queen" model="res.partner">
+        <field
+            name="default_fr_directory_line_id"
+            ref="demo_burger_queen_directory_line1"
+        />
+    </record>
+
+    <record id="demo_company_burger_queen" model="res.company" forcecreate="1">
+        <field name="name">Burger Queen</field>
+        <field name="partner_id" ref="partner_demo_burger_queen" />
+    </record>
+
+    <function model="res.company" name="_onchange_country_id">
+        <value eval="[ref('demo_company_burger_queen')]" />
+    </function>
+    <function model="res.users" name="write">
+        <value
+            eval="[ref('base.user_root'), ref('base.user_admin'), ref('base.user_demo')]"
+        />
+        <value eval="{'company_ids': [(4, ref('demo_company_burger_queen'))]}" />
+    </function>
+    <function model="account.chart.template" name="try_loading">
+        <value eval="[]" />
+        <value>fr</value>
+        <value model="res.company" eval="ref('demo_company_burger_queen')" />
+        <value name="install_demo" eval="True" />
+    </function>
+</odoo>


### PR DESCRIPTION
Salut @alexis-via 

J'ai ajouté des données de démo avec les lignes d'annuaire, si ça t'intéresse. Je suis toujours obligé de modifier le SIREN à la main dans la base postgresql mais au moins les lignes d'annuaire sont correctement créées sans avoir besoin de tout repasser en readonly=False.

Pour info, j'ai commencé les tests avec le module account_peppol et account_edi_ubl_cii et j'arrive à générer et envoyer une facture à superPDP avec quelques hacks que je mettrai dans un module à part, cf. https://github.com/lefilament/fr-einvoicing/pull/1/changes
