### PR TITLE
[FIX] err is reinitialized since used in except Exception

### DIFF
--- a/l10n_fr_einvoicing/models/fr_einvoicing_flow.py
+++ b/l10n_fr_einvoicing/models/fr_einvoicing_flow.py
@@ -605,12 +605,13 @@ class FrEinvoicingFlow(models.Model):
             move_id = err = None
             try:
                 move_id = self._import_supplier_invoice(result)
-            except Exception as err:
+            except Exception as error:
                 msg = (
                     f"Error in creation of the supplier invoice/refund from flow "
-                    f"{self.display_name} ID {self.id}: {err}"
+                    f"{self.display_name} ID {self.id}: {error}"
                 )
                 log_obj._warning_log(result, msg)
+                err = error
             if move_id:
                 flow_vals = {"state": "done"}
                 if "updated_count" in result:


### PR DESCRIPTION
When import fails,
an exception is caught by https://github.com/akretion/fr-einvoicing/blob/ecbf6f240f2d9d6bc7205a10106436427febf1cc/l10n_fr_einvoicing/models/fr_einvoicing_flow.py#L604

This uses err as Exception and therefore err does not exist anymore when you go back to execution later and if err: on line 624 raises a traceback :

```
2026-06-16 12:25:50,742 210193 ERROR test_factu_elec18 odoo.http: Exception during request handling. 
Traceback (most recent call last):
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 2577, in __call__
    response = request._serve_db()
               ^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 2104, in _serve_db
    return self._transactioning(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 2167, in _transactioning
    return service_model.retrying(func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/service/model.py", line 157, in retrying
    result = func()
             ^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 2134, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 2382, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/http.py", line 754, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/addons/web/controllers/dataset.py", line 42, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/ocb/odoo/api.py", line 535, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/other_repos/fr-einvoicing/l10n_fr_einvoicing/models/account_journal.py", line 17, in fr_einvoicing_run_import_button
    action = self.company_id.fr_ctc_run_import_log_action("Journal button")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/other_repos/fr-einvoicing/l10n_fr_einvoicing/models/res_company.py", line 267, in fr_ctc_run_import_log_action
    _, result = self.fr_ctc_run_import_log(origin)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/other_repos/fr-einvoicing/l10n_fr_einvoicing/models/res_company.py", line 314, in fr_ctc_run_import_log
    flows = self._fr_ctc_run_import(session, result)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/dev/odoo18/other_repos/fr-einvoicing/l10n_fr_einvoicing/models/res_company.py", line 410, in _fr_ctc_run_import
    flow._process(result)
  File "/home/user/dev/odoo18/other_repos/fr-einvoicing/l10n_fr_einvoicing/models/fr_einvoicing_flow.py", line 624, in _process
    if err:
       ^^^
UnboundLocalError: cannot access local variable 'err' where it is not associated with a value
```