### PR TITLE
fix: err variable not found after except context

### DIFF
--- a/l10n_fr_einvoicing/models/fr_einvoicing_flow.py
+++ b/l10n_fr_einvoicing/models/fr_einvoicing_flow.py
@@ -601,10 +601,11 @@ class FrEinvoicingFlow(models.Model):
             move_id = err = None
             try:
                 move_id = self._import_supplier_invoice(result)
-            except Exception as err:
+            except Exception as e:
+                err = e
                 msg = (
                     f"Error in creation of the supplier invoice/refund from flow "
-                    f"{self.display_name} ID {self.id}: {err}"
+                    f"{self.display_name} ID {self.id}: {e}"
                 )
                 log_obj._warning_log(result, msg)
             if move_id:


### PR DESCRIPTION
err est assigné deux fois dont la deuxieme fois sur le context except
Hors quand on quitte ce contexte, la variable est supprimé d'ou l'erreur sur le `if err:`
J'ai vérifié le comportement sur python 3.10 et 3.13

```bash
>>> err = None
>>> err
>>> try:
...     raise
... except Exception as err:
...     pass
... 
>>> err
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import platform
    ^^^
NameError: name 'err' is not defined
``` 