### PR TITLE
[ADD] l10n_fr_einvoicing_directory_import: maintain directory lines v…

### DIFF
--- a/l10n_fr_einvoicing_directory_import/__init__.py
+++ b/l10n_fr_einvoicing_directory_import/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/l10n_fr_einvoicing_directory_import/__manifest__.py
+++ b/l10n_fr_einvoicing_directory_import/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Sudokeys
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "France eInvoicing Directory Import/Export (CSV)",
+    "version": "18.0.1.0.0",
+    "category": "Accounting/Localizations/EDI",
+    "summary": "Maintain fr.directory.line manually via CSV export/import "
+    "when the AFNOR directory API is not available",
+    "author": "Sudokeys, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/fr-einvoicing",
+    "license": "AGPL-3",
+    "depends": [
+        "l10n_fr_einvoicing",
+    ],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizards/fr_directory_csv_wizard_views.xml",
+    ],
+    "installable": True,
+}

--- a/l10n_fr_einvoicing_directory_import/examples/exemple-retour-annuaire.csv
+++ b/l10n_fr_einvoicing_directory_import/examples/exemple-retour-annuaire.csv
@@ -1,0 +1,4 @@
+siren,siret,routing_code,routing_code_name,state,commitment_required
+497828095,49782809500012,,,active,0
+450487905,45048790500018,SERVICE_COMPTA,Comptabilité,active,1
+503908576,,,,upcoming,0

--- a/l10n_fr_einvoicing_directory_import/i18n/fr.po
+++ b/l10n_fr_einvoicing_directory_import/i18n/fr.po
@@ -1,0 +1,235 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_einvoicing_directory_import
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-27 08:13+0000\n"
+"PO-Revision-Date: 2026-07-27 08:13+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "%(c)s SIREN exported in %(f)s file(s) (max 5000 lines / 1 MB each)."
+msgstr "%(c)s SIREN exportés dans %(f)s fichier(s) (max 5000 lignes / 1 Mo chacun)."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "1. Export SIREN (directory deposit)"
+msgstr "1. Export des SIREN (dépôt annuaire)"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "2. Import the directory return"
+msgstr "2. Import du retour de l'annuaire"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"<i class=\"fa fa-external-link me-1\"/>facturation.chorus-"
+"pro.gouv.fr/annuaire"
+msgstr ""
+"<i class=\"fa fa-external-link me-1\"/>facturation.chorus-"
+"pro.gouv.fr/annuaire"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Close"
+msgstr "Fermer"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__import_file
+msgid "Directory return CSV"
+msgstr "CSV retour de l'annuaire"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.ui.menu,name:l10n_fr_einvoicing_directory_import.fr_directory_csv_menu
+msgid "Directory — CSV import/export"
+msgstr "Annuaire — Import/Export CSV"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "Empty or unreadable CSV file."
+msgstr "Fichier CSV vide ou illisible."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__export_filename
+msgid "Export Filename"
+msgstr "Nom du fichier exporté"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,help:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__only_missing
+msgid ""
+"Export only companies that do not have any directory line yet (i.e. not "
+"registered in the directory)."
+msgstr ""
+"N'exporte que les sociétés qui n'ont encore aucune ligne d'annuaire "
+"(c.-à-d. non enregistrées dans l'annuaire)."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.actions.act_window,name:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_action
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "France eInvoicing — Directory (CSV import/export)"
+msgstr "Facturation électronique FR — Annuaire (import/export CSV)"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Generate SIREN CSV"
+msgstr "Générer le CSV des SIREN"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Generated file"
+msgstr "Fichier généré"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__import_filename
+msgid "Import Filename"
+msgstr "Nom du fichier importé"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid ""
+"Import done: %(c)s created, %(u)s updated, %(s)s skipped, %(a)s ambiguous."
+msgstr ""
+"Import terminé : %(c)s créée(s), %(u)s mise(s) à jour, %(s)s ignorée(s), "
+"%(a)s ambiguë(s)."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Import return CSV"
+msgstr "Importer le CSV retour"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model,name:l10n_fr_einvoicing_directory_import.model_fr_directory_csv_wizard
+msgid "Import/Export eInvoicing directory via CSV"
+msgstr "Import/Export de l'annuaire e-facturation via CSV"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Mis à jour par"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__write_date
+msgid "Last Updated on"
+msgstr "Mis à jour le"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "No SIREN column found. Columns: %s"
+msgstr "Aucune colonne SIREN trouvée. Colonnes : %s"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "No SIREN to export for the selected companies."
+msgstr "Aucun SIREN à exporter pour les sociétés sélectionnées."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"Official directory (deposit the SIREN file, then download the\n"
+"                    return):"
+msgstr ""
+"Annuaire officiel (déposez le fichier SIREN, puis téléchargez le\n"
+"                    retour) :"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"One SIREN per line, without header — to deposit on the\n"
+"                    official directory. Files are capped at 5000 lines / 1 MB;\n"
+"                    a ZIP of several CSV is produced when needed."
+msgstr ""
+"Un SIREN par ligne, sans en-tête — à déposer sur l'annuaire\n"
+"                    officiel. Les fichiers sont limités à 5000 lignes / 1 Mo ;\n"
+"                    un ZIP de plusieurs CSV est produit si besoin."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__only_missing
+msgid "Only companies without a directory line"
+msgstr "Uniquement les sociétés sans ligne d'annuaire"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "Please upload the directory return CSV first."
+msgstr "Chargez d'abord le CSV retour de l'annuaire."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__result_summary
+msgid "Result Summary"
+msgstr "Résumé de l'import"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Return CSV"
+msgstr "CSV retour"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid ""
+"Row %(n)s: SIREN %(s)s is shared by several companies — linked to %(p)s."
+msgstr ""
+"Ligne %(n)s : le SIREN %(s)s est partagé par plusieurs sociétés — rattaché "
+"à %(p)s."
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "Row %(n)s: no partner found for SIREN %(s)s."
+msgstr "Ligne %(n)s : aucun partenaire trouvé pour le SIREN %(s)s."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__export_file
+msgid "SIREN file"
+msgstr "Fichier SIREN"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"Upload the CSV returned by the directory (Chorus Pro format),\n"
+"                    then import it to create/update the directory lines."
+msgstr ""
+"Chargez le CSV renvoyé par l'annuaire (format Chorus Pro),\n"
+"                    puis importez-le pour créer/mettre à jour les lignes "
+"d'annuaire."
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model,name:l10n_fr_einvoicing_directory_import.model_fr_directory_line
+msgid "eInvoicing Directory Line for France"
+msgstr "Ligne d'annuaire e-facturation pour la France"

--- a/l10n_fr_einvoicing_directory_import/i18n/fr.po
+++ b/l10n_fr_einvoicing_directory_import/i18n/fr.po
@@ -230,6 +230,18 @@ msgstr ""
 "d'annuaire."
 
 #. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__result_partner_ids
+msgid "Updated companies"
+msgstr "Sociétés mises à jour"
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "View updated companies"
+msgstr "Voir les sociétés mises à jour"
+
+#. module: l10n_fr_einvoicing_directory_import
 #: model:ir.model,name:l10n_fr_einvoicing_directory_import.model_fr_directory_line
 msgid "eInvoicing Directory Line for France"
 msgstr "Ligne d'annuaire e-facturation pour la France"

--- a/l10n_fr_einvoicing_directory_import/i18n/l10n_fr_einvoicing_directory_import.pot
+++ b/l10n_fr_einvoicing_directory_import/i18n/l10n_fr_einvoicing_directory_import.pot
@@ -1,0 +1,218 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_einvoicing_directory_import
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e-20260630\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-27 08:13+0000\n"
+"PO-Revision-Date: 2026-07-27 08:13+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "%(c)s SIREN exported in %(f)s file(s) (max 5000 lines / 1 MB each)."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "1. Export SIREN (directory deposit)"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "2. Import the directory return"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"<i class=\"fa fa-external-link me-1\"/>facturation.chorus-"
+"pro.gouv.fr/annuaire"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Close"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__import_file
+msgid "Directory return CSV"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.ui.menu,name:l10n_fr_einvoicing_directory_import.fr_directory_csv_menu
+msgid "Directory — CSV import/export"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "Empty or unreadable CSV file."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__export_filename
+msgid "Export Filename"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,help:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__only_missing
+msgid ""
+"Export only companies that do not have any directory line yet (i.e. not "
+"registered in the directory)."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.actions.act_window,name:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_action
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "France eInvoicing — Directory (CSV import/export)"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Generate SIREN CSV"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Generated file"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__import_filename
+msgid "Import Filename"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid ""
+"Import done: %(c)s created, %(u)s updated, %(s)s skipped, %(a)s ambiguous."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Import return CSV"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model,name:l10n_fr_einvoicing_directory_import.model_fr_directory_csv_wizard
+msgid "Import/Export eInvoicing directory via CSV"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "No SIREN column found. Columns: %s"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "No SIREN to export for the selected companies."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"Official directory (deposit the SIREN file, then download the\n"
+"                    return):"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"One SIREN per line, without header — to deposit on the\n"
+"                    official directory. Files are capped at 5000 lines / 1 MB;\n"
+"                    a ZIP of several CSV is produced when needed."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__only_missing
+msgid "Only companies without a directory line"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+msgid "Please upload the directory return CSV first."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__result_summary
+msgid "Result Summary"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "Return CSV"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid ""
+"Row %(n)s: SIREN %(s)s is shared by several companies — linked to %(p)s."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py:0
+msgid "Row %(n)s: no partner found for SIREN %(s)s."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__export_file
+msgid "SIREN file"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid ""
+"Upload the CSV returned by the directory (Chorus Pro format),\n"
+"                    then import it to create/update the directory lines."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model:ir.model,name:l10n_fr_einvoicing_directory_import.model_fr_directory_line
+msgid "eInvoicing Directory Line for France"
+msgstr ""

--- a/l10n_fr_einvoicing_directory_import/i18n/l10n_fr_einvoicing_directory_import.pot
+++ b/l10n_fr_einvoicing_directory_import/i18n/l10n_fr_einvoicing_directory_import.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e-20260630\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 08:13+0000\n"
-"PO-Revision-Date: 2026-07-27 08:13+0000\n"
+"POT-Creation-Date: 2026-07-27 08:20+0000\n"
+"PO-Revision-Date: 2026-07-27 08:20+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -206,10 +206,22 @@ msgid "SIREN file"
 msgstr ""
 
 #. module: l10n_fr_einvoicing_directory_import
+#. odoo-python
+#: code:addons/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py:0
+#: model:ir.model.fields,field_description:l10n_fr_einvoicing_directory_import.field_fr_directory_csv_wizard__result_partner_ids
+msgid "Updated companies"
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
 #: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
 msgid ""
 "Upload the CSV returned by the directory (Chorus Pro format),\n"
 "                    then import it to create/update the directory lines."
+msgstr ""
+
+#. module: l10n_fr_einvoicing_directory_import
+#: model_terms:ir.ui.view,arch_db:l10n_fr_einvoicing_directory_import.fr_directory_csv_wizard_form
+msgid "View updated companies"
 msgstr ""
 
 #. module: l10n_fr_einvoicing_directory_import

--- a/l10n_fr_einvoicing_directory_import/models/__init__.py
+++ b/l10n_fr_einvoicing_directory_import/models/__init__.py
@@ -1,0 +1,1 @@
+from . import fr_directory_line

--- a/l10n_fr_einvoicing_directory_import/models/__init__.py
+++ b/l10n_fr_einvoicing_directory_import/models/__init__.py
@@ -1,1 +1,2 @@
 from . import fr_directory_line
+from . import account_move

--- a/l10n_fr_einvoicing_directory_import/models/account_move.py
+++ b/l10n_fr_einvoicing_directory_import/models/account_move.py
@@ -1,6 +1,10 @@
 # Copyright 2026 Sudokeys
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+import logging
+
+from odoo import fields, models, tools
+
+logger = logging.getLogger(__name__)
 
 
 class AccountMove(models.Model):
@@ -13,3 +17,20 @@ class AccountMove(models.Model):
     # and the import gets killed by the server time limit long before finishing.
     # Indexing it also benefits every partner-centric accounting screen.
     commercial_partner_id = fields.Many2one(index=True)
+
+    def init(self):
+        # `index=True` above is enough on a clean database, but the field is
+        # inherited: any module redefining it without `index` would drop the
+        # index again. Creating it here as well makes the module self-healing —
+        # `create_index` is a no-op when the index already exists.
+        super().init()
+        tools.create_index(
+            self._cr,
+            "account_move_commercial_partner_id_index",
+            self._table,
+            ["commercial_partner_id"],
+        )
+        logger.info(
+            "account_move.commercial_partner_id index ensured "
+            "(directory import performance)"
+        )

--- a/l10n_fr_einvoicing_directory_import/models/account_move.py
+++ b/l10n_fr_einvoicing_directory_import/models/account_move.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Sudokeys
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    # Odoo does not index this column. Resolving a partner's directory status
+    # walks its invoices, so the directory import runs one such lookup per
+    # company: without an index each one is a sequential scan of the whole
+    # account_move table (877k rows on the FPV database, tens of seconds each),
+    # and the import gets killed by the server time limit long before finishing.
+    # Indexing it also benefits every partner-centric accounting screen.
+    commercial_partner_id = fields.Many2one(index=True)

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -197,6 +197,14 @@ class FrDirectoryLine(models.Model):
             siret = partner._get_siret(raise_if_none=False)
             if siret:
                 vals["fr_directory_siret"] = siret
+            # Convenience: when the partner ends up with a single active line and
+            # no default set, use it as the default routing line (BT-49). The
+            # field is a manual selector natively; the directory return usually
+            # confirms one address per company, so this saves a manual pick.
+            if not partner.default_fr_directory_line_id:
+                active_lines = partner.fr_directory_line_ids
+                if len(active_lines) == 1:
+                    vals["default_fr_directory_line_id"] = active_lines.id
             partner.sudo().write(vals)
 
     @api.model

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -7,7 +7,7 @@ import csv
 import io
 import logging
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 logger = logging.getLogger(__name__)
@@ -119,6 +119,7 @@ class FrDirectoryLine(models.Model):
         created = updated = skipped = ambiguous = 0
         errors = []
         affected = set()
+        synced = set()
         for line_no, row in enumerate(reader, start=2):
             siren = (row.get(cols["siren"]) or "").strip().replace(" ", "")
             if not siren.isdigit() or len(siren) != 9:
@@ -141,6 +142,7 @@ class FrDirectoryLine(models.Model):
                     _("Row %(n)s: SIREN %(s)s is shared by several companies — "
                       "linked to %(p)s.", n=line_no, s=siren, p=partner.display_name)
                 )
+            synced.add(partner.id)
             existing = self.with_context(active_test=False).search(
                 [("partner_id", "=", partner.id),
                  ("identifier", "=", vals["identifier"])],
@@ -161,6 +163,10 @@ class FrDirectoryLine(models.Model):
                 self.sudo().create(dict(vals, partner_id=partner.id))
                 created += 1
                 affected.add(partner.id)
+        if synced:
+            self._directory_mark_partners_registered(
+                self.env["res.partner"].browse(list(synced))
+            )
         logger.info(
             "Directory CSV import: %s created, %s updated, %s skipped, "
             "%s ambiguous.", created, updated, skipped, ambiguous,
@@ -170,6 +176,28 @@ class FrDirectoryLine(models.Model):
             "ambiguous": ambiguous, "errors": errors,
             "partner_ids": list(affected),
         }
+
+    @api.model
+    def _directory_mark_partners_registered(self, partners):
+        """Mark partners as present in the directory after a CSV import.
+
+        The native module fills these partner-level fields during the API sync;
+        the CSV import must do the same, otherwise the directory section on the
+        partner (status, default line selector) stays hidden and BT-49 cannot
+        resolve. Entity type defaults to ``private`` when not already set.
+        """
+        today = fields.Date.context_today(self)
+        for partner in partners.commercial_partner_id:
+            vals = {"fr_directory_last_sync_date": today}
+            if not partner.fr_directory_entity_type:
+                vals["fr_directory_entity_type"] = "private"
+            siren = partner._get_siren(raise_if_none=False)
+            if siren:
+                vals["fr_directory_siren"] = siren
+            siret = partner._get_siret(raise_if_none=False)
+            if siret:
+                vals["fr_directory_siret"] = siret
+            partner.sudo().write(vals)
 
     @api.model
     def _directory_partner_index(self):

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -118,6 +118,7 @@ class FrDirectoryLine(models.Model):
         index = self._directory_partner_index()
         created = updated = skipped = ambiguous = 0
         errors = []
+        affected = set()
         for line_no, row in enumerate(reader, start=2):
             siren = (row.get(cols["siren"]) or "").strip().replace(" ", "")
             if not siren.isdigit() or len(siren) != 9:
@@ -155,9 +156,11 @@ class FrDirectoryLine(models.Model):
                 if wvals:
                     existing.sudo().write(wvals)
                     updated += 1
+                    affected.add(partner.id)
             else:
                 self.sudo().create(dict(vals, partner_id=partner.id))
                 created += 1
+                affected.add(partner.id)
         logger.info(
             "Directory CSV import: %s created, %s updated, %s skipped, "
             "%s ambiguous.", created, updated, skipped, ambiguous,
@@ -165,6 +168,7 @@ class FrDirectoryLine(models.Model):
         return {
             "created": created, "updated": updated, "skipped": skipped,
             "ambiguous": ambiguous, "errors": errors,
+            "partner_ids": list(affected),
         }
 
     @api.model

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -26,6 +26,12 @@ STATE_ALIASES = {
 VALID_TYPES = ("siren", "siret", "routing_code", "suffix", "error")
 BOOL_TRUE = {"1", "true", "vrai", "oui", "yes", "x", "o"}
 
+# Partners processed per transaction during the import. Each batch is
+# committed on its own: marking partners invalidates a stored compute on
+# account.move, whose recompute would otherwise pile up over the entire
+# invoice history and exhaust memory on a production-sized database.
+DIRECTORY_IMPORT_BATCH = 200
+
 # The State directory caps each deposited file at 5000 lines and 1 MB.
 DIRECTORY_MAX_LINES = 5000
 DIRECTORY_MAX_BYTES = 1_000_000
@@ -162,38 +168,70 @@ class FrDirectoryLine(models.Model):
             ):
                 existing_map[(line.partner_id.id, line.identifier)] = line
 
-        # Pass 2 — group the writes and create in a single call. Tracking is
-        # disabled: an import must not post thousands of chatter messages.
+        # Pass 2 — write in batches of partners, committing between each.
+        #
+        # Marking a partner as present in the directory invalidates the stored
+        # `fr_einvoicing_required` on account.move, which depends on the
+        # partner's entity type. Doing it for every partner in one transaction
+        # makes Odoo recompute that field over the partner's whole invoice
+        # history at flush time — on a production database (877k moves here)
+        # the process runs out of memory. Committing per batch keeps each
+        # recompute bounded and releases the cache as we go.
+        #
+        # Trade-off: the import is no longer atomic. That is deliberate — a
+        # directory return is idempotent (upsert by partner + identifier), so
+        # re-running it after a failure resumes where it stopped.
         Line = self.sudo().with_context(tracking_disable=True)
-        to_create = []
-        write_groups = {}
+        by_partner = {}
         for partner, vals in parsed:
-            existing = existing_map.get((partner.id, vals["identifier"]))
-            if existing:
-                wvals = {
-                    key: value
-                    for key, value in vals.items()
-                    if key != "identifier"
-                    and (existing[key] or False) != (value or False)
-                }
-                if wvals:
-                    write_groups.setdefault(
-                        tuple(sorted(wvals.items(), key=lambda kv: kv[0])), []
-                    ).append(existing.id)
-                    updated += 1
-                    affected.add(partner.id)
-            else:
-                to_create.append(dict(vals, partner_id=partner.id))
-                created += 1
-                affected.add(partner.id)
-        for wvals_items, line_ids in write_groups.items():
-            Line.browse(line_ids).write(dict(wvals_items))
-        if to_create:
-            Line.create(to_create)
+            by_partner.setdefault(partner.id, []).append(vals)
+        all_partner_ids = list(by_partner)
+        batches = range(0, len(all_partner_ids), DIRECTORY_IMPORT_BATCH)
 
-        if synced:
-            self._directory_mark_partners_registered(
-                self.env["res.partner"].browse(list(synced))
+        for offset in batches:
+            batch_ids = all_partner_ids[offset:offset + DIRECTORY_IMPORT_BATCH]
+            to_create = []
+            write_groups = {}
+            for partner_id in batch_ids:
+                for vals in by_partner[partner_id]:
+                    existing = existing_map.get((partner_id, vals["identifier"]))
+                    if existing:
+                        wvals = {
+                            key: value
+                            for key, value in vals.items()
+                            if key != "identifier"
+                            and (existing[key] or False) != (value or False)
+                        }
+                        if wvals:
+                            write_groups.setdefault(
+                                tuple(sorted(wvals.items(), key=lambda kv: kv[0])), []
+                            ).append(existing.id)
+                            updated += 1
+                            affected.add(partner_id)
+                    else:
+                        to_create.append(dict(vals, partner_id=partner_id))
+                        created += 1
+                        affected.add(partner_id)
+            for wvals_items, line_ids in write_groups.items():
+                Line.browse(line_ids).write(dict(wvals_items))
+            if to_create:
+                Line.create(to_create)
+
+            batch_synced = [pid for pid in batch_ids if pid in synced]
+            if batch_synced:
+                self._directory_mark_partners_registered(
+                    self.env["res.partner"].browse(batch_synced)
+                )
+
+            # Flush, commit, then drop the cache: without this the recomputes
+            # of the whole run pile up until the final flush.
+            self.env.flush_all()
+            self.env.cr.commit()
+            self.env.invalidate_all()
+            logger.info(
+                "Directory CSV import: %s/%s partners processed.",
+                min(offset + DIRECTORY_IMPORT_BATCH, len(all_partner_ids)),
+                len(all_partner_ids),
             )
         logger.info(
             "Directory CSV import: %s created, %s updated, %s skipped, "

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -120,6 +120,13 @@ class FrDirectoryLine(models.Model):
         errors = []
         affected = set()
         synced = set()
+
+        # Pass 1 — parse the whole file and resolve partners, without touching
+        # the database. A directory return holds one row per company: doing an
+        # ORM search and a write per row costs one query each and re-triggers
+        # the stored computes on res.partner every time, which blows past the
+        # server's request time limit on real files (thousands of rows).
+        parsed = []
         for line_no, row in enumerate(reader, start=2):
             siren = (row.get(cols["siren"]) or "").strip().replace(" ", "")
             if not siren.isdigit() or len(siren) != 9:
@@ -143,11 +150,25 @@ class FrDirectoryLine(models.Model):
                       "linked to %(p)s.", n=line_no, s=siren, p=partner.display_name)
                 )
             synced.add(partner.id)
-            existing = self.with_context(active_test=False).search(
-                [("partner_id", "=", partner.id),
-                 ("identifier", "=", vals["identifier"])],
-                limit=1,
-            )
+            parsed.append((partner, vals))
+
+        # Pre-load every existing line of the partners involved in one query,
+        # indexed by (partner, identifier) — the key used for the upsert.
+        existing_map = {}
+        if parsed:
+            partner_ids = list({partner.id for partner, _vals in parsed})
+            for line in self.with_context(active_test=False).search(
+                [("partner_id", "in", partner_ids)]
+            ):
+                existing_map[(line.partner_id.id, line.identifier)] = line
+
+        # Pass 2 — group the writes and create in a single call. Tracking is
+        # disabled: an import must not post thousands of chatter messages.
+        Line = self.sudo().with_context(tracking_disable=True)
+        to_create = []
+        write_groups = {}
+        for partner, vals in parsed:
+            existing = existing_map.get((partner.id, vals["identifier"]))
             if existing:
                 wvals = {
                     key: value
@@ -156,13 +177,20 @@ class FrDirectoryLine(models.Model):
                     and (existing[key] or False) != (value or False)
                 }
                 if wvals:
-                    existing.sudo().write(wvals)
+                    write_groups.setdefault(
+                        tuple(sorted(wvals.items(), key=lambda kv: kv[0])), []
+                    ).append(existing.id)
                     updated += 1
                     affected.add(partner.id)
             else:
-                self.sudo().create(dict(vals, partner_id=partner.id))
+                to_create.append(dict(vals, partner_id=partner.id))
                 created += 1
                 affected.add(partner.id)
+        for wvals_items, line_ids in write_groups.items():
+            Line.browse(line_ids).write(dict(wvals_items))
+        if to_create:
+            Line.create(to_create)
+
         if synced:
             self._directory_mark_partners_registered(
                 self.env["res.partner"].browse(list(synced))
@@ -187,7 +215,13 @@ class FrDirectoryLine(models.Model):
         resolve. Entity type defaults to ``private`` when not already set.
         """
         today = fields.Date.context_today(self)
-        for partner in partners.commercial_partner_id:
+        # One write per partner would mean thousands of UPDATE plus as many
+        # recomputes of the stored directory fields. Partners sharing the exact
+        # same values are written together, and tracking is disabled so the
+        # import doesn't fill the chatter.
+        Partner = partners.sudo().with_context(tracking_disable=True)
+        groups = {}
+        for partner in Partner.commercial_partner_id:
             vals = {"fr_directory_last_sync_date": today}
             if not partner.fr_directory_entity_type:
                 vals["fr_directory_entity_type"] = "private"
@@ -205,7 +239,11 @@ class FrDirectoryLine(models.Model):
                 active_lines = partner.fr_directory_line_ids
                 if len(active_lines) == 1:
                     vals["default_fr_directory_line_id"] = active_lines.id
-            partner.sudo().write(vals)
+            groups.setdefault(
+                tuple(sorted(vals.items(), key=lambda kv: kv[0])), []
+            ).append(partner.id)
+        for vals_items, partner_ids in groups.items():
+            Partner.browse(partner_ids).write(dict(vals_items))
 
     @api.model
     def _directory_partner_index(self):

--- a/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
+++ b/l10n_fr_einvoicing_directory_import/models/fr_directory_line.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Sudokeys
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+#
+# Official French e-invoicing directory (Chorus Pro):
+# https://facturation.chorus-pro.gouv.fr/annuaire/
+import csv
+import io
+import logging
+
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+logger = logging.getLogger(__name__)
+
+# Map the status returned by the directory to the ``state`` field.
+STATE_ALIASES = {
+    "": "inactive",
+    "enabled": "active",
+    "active": "active",
+    "registered": "active",
+    "upcoming": "upcoming",
+    "in_progress": "upcoming",
+    "disabled": "disabled",
+    "inactive": "inactive",
+}
+VALID_TYPES = ("siren", "siret", "routing_code", "suffix", "error")
+BOOL_TRUE = {"1", "true", "vrai", "oui", "yes", "x", "o"}
+
+# The State directory caps each deposited file at 5000 lines and 1 MB.
+DIRECTORY_MAX_LINES = 5000
+DIRECTORY_MAX_BYTES = 1_000_000
+
+
+class FrDirectoryLine(models.Model):
+    _inherit = "fr.directory.line"
+
+    # ------------------------------------------------------------------
+    # Export: CSV of SIREN numbers to deposit on the State directory
+    # ------------------------------------------------------------------
+    @api.model
+    def _directory_export_siren_list(self, partners):
+        """Return the ordered list of unique SIREN numbers of the partners."""
+        sirens = []
+        seen = set()
+        for partner in partners:
+            siren = partner._get_siren(raise_if_none=False)
+            if siren and siren not in seen:
+                seen.add(siren)
+                sirens.append(siren)
+        return sirens
+
+    @api.model
+    def _directory_export_siren_chunks(self, partners):
+        """Return a list of CSV chunks (bytes), one SIREN per line, WITHOUT a
+        header and with ``\\n`` line endings. Each chunk stays within the State
+        directory limits (<= 5000 lines and <= 1 MB), splitting when needed."""
+        chunks = []
+        buf = io.StringIO()
+        writer = csv.writer(buf, lineterminator="\n")
+        lines = 0
+        for siren in self._directory_export_siren_list(partners):
+            if lines >= DIRECTORY_MAX_LINES or (
+                buf.tell() + len(siren) + 1 > DIRECTORY_MAX_BYTES
+            ):
+                chunks.append(buf.getvalue().encode("utf-8"))
+                buf = io.StringIO()
+                writer = csv.writer(buf, lineterminator="\n")
+                lines = 0
+            writer.writerow([siren])
+            lines += 1
+        if lines:
+            chunks.append(buf.getvalue().encode("utf-8"))
+        return chunks
+
+    @api.model
+    def _directory_export_siren_csv(self, partners):
+        """Return a single CSV (bytes) with every SIREN (no size limit).
+
+        Kept for callers that do not care about the directory 5000-lines / 1 MB
+        deposit limits; the wizard uses :meth:`_directory_export_siren_chunks`.
+        """
+        out = io.StringIO()
+        writer = csv.writer(out, lineterminator="\n")
+        for siren in self._directory_export_siren_list(partners):
+            writer.writerow([siren])
+        return out.getvalue().encode("utf-8")
+
+    # ------------------------------------------------------------------
+    # Import: directory return CSV -> create/update directory lines
+    # ------------------------------------------------------------------
+    @api.model
+    def _directory_import_csv(self, content):
+        """Create/update directory lines from the directory return CSV.
+
+        Understands the Chorus Pro directory export (columns "SIREN" and
+        "Adresse de facturation" / "Adresse de facturation active") as well as
+        a canonical format (siren, siret, identifier, routing_code, state...).
+        Each row is matched to its commercial partner by SIREN and upserted by
+        (partner, identifier), like the native API sync. The delimiter (``,``
+        or ``;``) is auto-detected.
+        """
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1")
+        sample = text[:2000]
+        delimiter = ";" if sample.count(";") > sample.count(",") else ","
+        reader = csv.DictReader(io.StringIO(text), delimiter=delimiter)
+        if not reader.fieldnames:
+            raise UserError(_("Empty or unreadable CSV file."))
+        cols = self._directory_detect_columns(reader.fieldnames)
+        if "siren" not in cols:
+            raise UserError(_(
+                "No SIREN column found. Columns: %s",
+                ", ".join(reader.fieldnames),
+            ))
+
+        index = self._directory_partner_index()
+        created = updated = skipped = ambiguous = 0
+        errors = []
+        for line_no, row in enumerate(reader, start=2):
+            siren = (row.get(cols["siren"]) or "").strip().replace(" ", "")
+            if not siren.isdigit() or len(siren) != 9:
+                skipped += 1
+                continue
+            vals = self._directory_row_to_vals(row, cols, siren)
+            partner, issue = self._directory_match_partner(
+                siren, vals.get("siret"), index
+            )
+            if not partner:
+                skipped += 1
+                errors.append(
+                    _("Row %(n)s: no partner found for SIREN %(s)s.",
+                      n=line_no, s=siren)
+                )
+                continue
+            if issue == "ambiguous":
+                ambiguous += 1
+                errors.append(
+                    _("Row %(n)s: SIREN %(s)s is shared by several companies — "
+                      "linked to %(p)s.", n=line_no, s=siren, p=partner.display_name)
+                )
+            existing = self.with_context(active_test=False).search(
+                [("partner_id", "=", partner.id),
+                 ("identifier", "=", vals["identifier"])],
+                limit=1,
+            )
+            if existing:
+                wvals = {
+                    key: value
+                    for key, value in vals.items()
+                    if key != "identifier"
+                    and (existing[key] or False) != (value or False)
+                }
+                if wvals:
+                    existing.sudo().write(wvals)
+                    updated += 1
+            else:
+                self.sudo().create(dict(vals, partner_id=partner.id))
+                created += 1
+        logger.info(
+            "Directory CSV import: %s created, %s updated, %s skipped, "
+            "%s ambiguous.", created, updated, skipped, ambiguous,
+        )
+        return {
+            "created": created, "updated": updated, "skipped": skipped,
+            "ambiguous": ambiguous, "errors": errors,
+        }
+
+    @api.model
+    def _directory_partner_index(self):
+        """Index companies by SIREN and by SIRET for partner matching."""
+        Partner = self.env["res.partner"]
+        companies = Partner.with_context(active_test=False).search(
+            [("is_company", "=", True)]
+        )
+        by_siren = {}
+        by_siret = {}
+        for partner in companies:
+            siren = partner._get_siren(raise_if_none=False)
+            if siren:
+                by_siren[siren] = by_siren.get(siren, Partner) | partner
+            siret = partner._get_siret(raise_if_none=False)
+            if siret:
+                by_siret.setdefault(siret, partner)
+        return {"siren": by_siren, "siret": by_siret}
+
+    @api.model
+    def _directory_match_partner(self, siren, siret, index):
+        """Return (commercial_partner, anomaly).
+
+        Prefer the SIRET (disambiguates when several companies share a SIREN);
+        otherwise match by SIREN. ``anomaly`` is 'ambiguous' when the SIREN maps
+        to several distinct companies.
+        """
+        empty = self.env["res.partner"]
+        if siret and siret in index["siret"]:
+            return index["siret"][siret].commercial_partner_id, None
+        partners = index["siren"].get(siren, empty)
+        commercials = partners.commercial_partner_id
+        if not commercials:
+            return empty, "no_partner"
+        if len(commercials) == 1:
+            return commercials, None
+        return commercials[0], "ambiguous"
+
+    @api.model
+    def _directory_detect_columns(self, fieldnames):
+        """Map each column to a role (Chorus Pro or canonical format)."""
+        cols = {}
+        for src in fieldnames:
+            low = (src or "").strip().lower()
+            if low == "siren":
+                cols["siren"] = src
+            elif "adresse de facturation" in low and "active" in low:
+                cols["active"] = src
+            elif "adresse de facturation" in low:
+                cols["identifier"] = src
+            elif low in ("identifier", "adresse"):
+                cols.setdefault("identifier", src)
+            elif low in ("state", "etat", "état"):
+                cols["state"] = src
+            elif low == "siret":
+                cols["siret"] = src
+            elif low in ("routing_code", "code_routage", "code routage"):
+                cols["routing_code"] = src
+            elif low in ("routing_code_name", "libelle", "libellé"):
+                cols["routing_code_name"] = src
+            elif low in ("commitment_required", "engagement"):
+                cols["commitment"] = src
+        return cols
+
+    @api.model
+    def _directory_row_to_vals(self, row, cols, siren):
+        """Turn a CSV row into fr.directory.line values."""
+        def val(role):
+            return (row.get(cols[role]) or "").strip() if role in cols else ""
+
+        identifier = val("identifier") or siren
+        rtype, siret, routing_code = self._directory_parse_identifier(
+            identifier, siren
+        )
+        if "active" in cols:
+            state = "active" if val("active").lower() in BOOL_TRUE else "disabled"
+        elif "state" in cols:
+            state = STATE_ALIASES.get(val("state").lower(), "active")
+        else:
+            state = "active"
+        return {
+            "identifier": identifier,
+            "type": rtype,
+            "siren": siren,
+            "siret": (val("siret") or siret) or False,
+            "routing_code": (val("routing_code") or routing_code) or False,
+            "routing_code_name": val("routing_code_name") or False,
+            "state": state,
+            "commitment_required": (
+                val("commitment").lower() in BOOL_TRUE if "commitment" in cols
+                else False
+            ),
+        }
+
+    @api.model
+    def _directory_parse_identifier(self, identifier, siren):
+        """Derive (type, siret, routing_code) from the identifier.
+
+        Formats: SIREN | SIREN_SIRET | SIREN_SIRET_RoutingCode | SIREN_Suffix.
+        The routing code may contain "_": it is whatever follows the SIRET.
+        """
+        parts = identifier.split("_")
+        siret = routing_code = False
+        if len(parts) == 1:
+            return "siren", siret, routing_code
+        second = parts[1]
+        is_siret = len(second) == 14 and second.isdigit()
+        if is_siret:
+            siret = second
+            if len(parts) == 2:
+                return "siret", siret, routing_code
+            routing_code = "_".join(parts[2:])
+            return "routing_code", siret, routing_code
+        # 2nd segment is not a SIRET => addressing suffix
+        return "suffix", siret, routing_code

--- a/l10n_fr_einvoicing_directory_import/security/ir.model.access.csv
+++ b/l10n_fr_einvoicing_directory_import/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_fr_directory_csv_wizard,fr.directory.csv.wizard,model_fr_directory_csv_wizard,account.group_account_manager,1,1,1,1

--- a/l10n_fr_einvoicing_directory_import/wizards/__init__.py
+++ b/l10n_fr_einvoicing_directory_import/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import fr_directory_csv_wizard

--- a/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py
+++ b/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py
@@ -1,0 +1,97 @@
+# Copyright 2026 Sudokeys
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import base64
+import io
+import zipfile
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class FrDirectoryCsvWizard(models.TransientModel):
+    _name = "fr.directory.csv.wizard"
+    _description = "Import/Export eInvoicing directory via CSV"
+
+    # Step 1: export the SIREN numbers to deposit on the directory
+    only_missing = fields.Boolean(
+        string="Only companies without a directory line",
+        default=True,
+        help="Export only companies that do not have any directory line yet "
+        "(i.e. not registered in the directory).",
+    )
+    export_file = fields.Binary(string="SIREN file", readonly=True)
+    export_filename = fields.Char(readonly=True)
+    # Step 2: import the directory return CSV
+    import_file = fields.Binary(string="Directory return CSV")
+    import_filename = fields.Char()
+    result_summary = fields.Text(readonly=True)
+
+    def action_export_siren(self):
+        self.ensure_one()
+        partners = self.env["res.partner"].browse(
+            self.env.context.get("active_ids") or []
+        )
+        if not partners:
+            partners = self.env["res.partner"].search(
+                [("is_company", "=", True), ("parent_id", "=", False)]
+            )
+        if self.only_missing:
+            # Drop companies that already have at least one directory line
+            # (active or not): they are already registered.
+            with_lines = self.env["fr.directory.line"].with_context(
+                active_test=False
+            ).search([("partner_id", "in", partners.ids)]).partner_id
+            partners = partners - with_lines
+        Line = self.env["fr.directory.line"]
+        chunks = Line._directory_export_siren_chunks(partners)
+        if not chunks:
+            raise UserError(
+                _("No SIREN to export for the selected companies.")
+            )
+        # A single CSV, or a ZIP of several CSV when the directory limits
+        # (5000 lines / 1 MB per file) require splitting.
+        if len(chunks) == 1:
+            data, name = chunks[0], "directory_siren.csv"
+        else:
+            zbuf = io.BytesIO()
+            with zipfile.ZipFile(zbuf, "w", zipfile.ZIP_DEFLATED) as zf:
+                for i, chunk in enumerate(chunks, start=1):
+                    zf.writestr("directory_siren_%02d.csv" % i, chunk)
+            data, name = zbuf.getvalue(), "directory_siren.zip"
+        count = len(Line._directory_export_siren_list(partners))
+        self.write({
+            "export_file": base64.b64encode(data),
+            "export_filename": name,
+            "result_summary": _(
+                "%(c)s SIREN exported in %(f)s file(s) "
+                "(max 5000 lines / 1 MB each).", c=count, f=len(chunks),
+            ),
+        })
+        return self._reopen()
+
+    def action_import(self):
+        self.ensure_one()
+        if not self.import_file:
+            raise UserError(_("Please upload the directory return CSV first."))
+        res = self.env["fr.directory.line"]._directory_import_csv(
+            base64.b64decode(self.import_file)
+        )
+        summary = _(
+            "Import done: %(c)s created, %(u)s updated, "
+            "%(s)s skipped, %(a)s ambiguous.",
+            c=res["created"], u=res["updated"], s=res["skipped"],
+            a=res.get("ambiguous", 0),
+        )
+        if res["errors"]:
+            summary += "\n\n" + "\n".join(res["errors"][:50])
+        self.write({"result_summary": summary})
+        return self._reopen()
+
+    def _reopen(self):
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": self._name,
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "new",
+        }

--- a/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py
+++ b/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard.py
@@ -25,6 +25,9 @@ class FrDirectoryCsvWizard(models.TransientModel):
     import_file = fields.Binary(string="Directory return CSV")
     import_filename = fields.Char()
     result_summary = fields.Text(readonly=True)
+    result_partner_ids = fields.Many2many(
+        "res.partner", string="Updated companies", readonly=True
+    )
 
     def action_export_siren(self):
         self.ensure_one()
@@ -84,8 +87,22 @@ class FrDirectoryCsvWizard(models.TransientModel):
         )
         if res["errors"]:
             summary += "\n\n" + "\n".join(res["errors"][:50])
-        self.write({"result_summary": summary})
+        self.write({
+            "result_summary": summary,
+            "result_partner_ids": [(6, 0, res.get("partner_ids", []))],
+        })
         return self._reopen()
+
+    def action_view_partners(self):
+        """Open the list of companies created/updated by the last import."""
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Updated companies"),
+            "res_model": "res.partner",
+            "view_mode": "list,form",
+            "domain": [("id", "in", self.result_partner_ids.ids)],
+        }
 
     def _reopen(self):
         return {

--- a/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
+++ b/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
@@ -48,6 +48,12 @@
 
                 <field name="result_summary" readonly="1" nolabel="1"
                        invisible="not result_summary"/>
+                <field name="result_partner_ids" invisible="1"/>
+                <div class="mt-2" invisible="not result_partner_ids">
+                    <button name="action_view_partners" type="object"
+                            string="View updated companies"
+                            class="btn-secondary"/>
+                </div>
                 <footer>
                     <button string="Close" class="btn-secondary"
                             special="cancel"/>

--- a/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
+++ b/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
@@ -1,0 +1,72 @@
+<odoo>
+
+    <record id="fr_directory_csv_wizard_form" model="ir.ui.view">
+        <field name="name">fr.directory.csv.wizard.form</field>
+        <field name="model">fr.directory.csv.wizard</field>
+        <field name="arch" type="xml">
+            <form string="France eInvoicing — Directory (CSV import/export)">
+                <div class="alert alert-info mb-3" role="alert">
+                    Official directory (deposit the SIREN file, then download the
+                    return):
+                    <a href="https://facturation.chorus-pro.gouv.fr/annuaire/"
+                       target="_blank" rel="noopener">
+                        <i class="fa fa-external-link me-1"/>facturation.chorus-pro.gouv.fr/annuaire</a>
+                </div>
+                <separator string="1. Export SIREN (directory deposit)"/>
+                <div class="text-muted">
+                    One SIREN per line, without header — to deposit on the
+                    official directory. Files are capped at 5000 lines / 1 MB;
+                    a ZIP of several CSV is produced when needed.
+                </div>
+                <group>
+                    <field name="only_missing"/>
+                </group>
+                <div class="mt-2 mb-3">
+                    <button name="action_export_siren" type="object"
+                            string="Generate SIREN CSV" class="btn-primary"/>
+                </div>
+                <group>
+                    <field name="export_file" filename="export_filename"
+                           string="Generated file" readonly="1"/>
+                    <field name="export_filename" invisible="1"/>
+                </group>
+
+                <separator string="2. Import the directory return"/>
+                <div class="text-muted">
+                    Upload the CSV returned by the directory (Chorus Pro format),
+                    then import it to create/update the directory lines.
+                </div>
+                <group>
+                    <field name="import_file" filename="import_filename"
+                           string="Return CSV"/>
+                    <field name="import_filename" invisible="1"/>
+                </group>
+                <div class="mt-2 mb-3">
+                    <button name="action_import" type="object"
+                            string="Import return CSV" class="btn-primary"/>
+                </div>
+
+                <field name="result_summary" readonly="1" nolabel="1"
+                       invisible="not result_summary"/>
+                <footer>
+                    <button string="Close" class="btn-secondary"
+                            special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="fr_directory_csv_wizard_action" model="ir.actions.act_window">
+        <field name="name">France eInvoicing — Directory (CSV import/export)</field>
+        <field name="res_model">fr.directory.csv.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem id="fr_directory_csv_menu"
+              name="Directory — CSV import/export"
+              parent="l10n_fr_einvoicing.fr_einvoicing_root"
+              action="fr_directory_csv_wizard_action"
+              sequence="20"/>
+
+</odoo>


### PR DESCRIPTION
…ia CSV

When the AFNOR directory API is not activated, this module lets users export the SIREN list to deposit on the official directory (headerless, one SIREN per line) and import the returned CSV (Chorus Pro format) to create/update fr.directory.line records. One CSV row maps to one directory line, matched to its partner by SIREN and disambiguated by SIRET when several companies share a SIREN. The line type (siren/siret/routing_code/suffix) is derived from the electronic address structure. A wizard exposes both steps.

Annuaire: https://facturation.chorus-pro.gouv.fr/annuaire/