### PR TITLE
[FIX] account_invoice_en16931: BT-152 is required on exempt invoice l…

### DIFF
--- a/account_invoice_en16931/models/account_move_line.py
+++ b/account_invoice_en16931/models/account_move_line.py
@@ -45,7 +45,13 @@ class AccountMoveLine(models.Model):
                 )
             assert vat_tax.unece_categ_code
             vat_dict = {"categ_code": vat_tax.unece_categ_code}
-            if vat_tax.unece_categ_code in ("S", "K", "G"):
+            # BT-152 is required on the line for every VAT category but O:
+            # BR-S-05 wants the rate, BR-Z-05, BR-E-05, BR-AE-05, BR-G-05 and
+            # BR-IC-05 all want an explicit 0, and only BR-O-05 wants it left
+            # out. Restricting this to S/K/G dropped BT-152 on exempt lines,
+            # which BR-E-05 rejects and which then breaks BR-FXEXT-E-08: the
+            # schematron sums no line at all against the E breakdown.
+            if vat_tax.unece_categ_code != "O":
                 vat_dict["vat_rate"] = vat_tax.amount
             if vat_tax.unece_categ_code not in ("S", "Z"):
                 assert vat_tax.unece_vatex_code


### PR DESCRIPTION
…ines

The line VAT rate was only emitted for categories S, K and G, so an exempt line (E), a zero-rated one (Z) or a reverse charge (AE) went out without BT-152 at all. BR-E-05 and its siblings require the rate to be there and to be 0; only category O, out of scope, may omit it (BR-O-05).

The knock-on effect is worse than the missing element: with no rate on the line, the schematron matches no line against the E VAT breakdown, so BR-FXEXT-E-08 (and BR-FREXT-E-08 on UBL) compares the taxable amount against a sum of zero lines and fails too. An invoice carrying a single exempt line is rejected by the base schematron in both CII and UBL.

Found while running the schematron checks against a Saxon server on the 19.0 port; the code is identical here, so 18.0 is affected the same way.