### PR TITLE
[FIX] l10n_fr_einvoicing_sale: ensure_one on empty recordset breaks action_confirm

### DIFF
--- a/l10n_fr_einvoicing_sale/models/sale_order.py
+++ b/l10n_fr_einvoicing_sale/models/sale_order.py
@@ -131,8 +131,8 @@ class SaleOrder(models.Model):
         return group_keys
 
     def _action_confirm(self):
-        self.ensure_one()
         for order in self:
+            order.ensure_one()
             order._fr_ctc_confirm_checks()
         return super()._action_confirm()
 


### PR DESCRIPTION
Fixes #40

`sale_subscription` (Odoo Enterprise) overrides `action_confirm()` to split `self` into a recurring and a non-recurring subset, then calls `super().action_confirm()` on each subset separately — including whichever one ends up empty:

```python
recurring_order = self.filtered(lambda o: o.is_subscription)
res_sub = super(SaleOrder, recurring_order).action_confirm()
res_other = super(SaleOrder, self - recurring_order).action_confirm()
```

`l10n_fr_einvoicing_sale._action_confirm()` calls `self.ensure_one()` before iterating, which raises `ValueError: Expected singleton` on the empty subset. In practice this breaks confirmation of *every* non-subscription sale order as soon as both modules are installed together — the recurring subset is empty for any regular quote, and the confirm call never reaches the order itself.

The fix moves `ensure_one()` inside the loop, where it is applied per-iteration (each `order` is already guaranteed to be a single record by `for order in self`) instead of on the whole recordset up front. An empty `self` then correctly falls through as a no-op, matching how the rest of the method already handles batches.