### PR TITLE
[18.0][FIX] account_invoice_en16931: drop the Discount decimal precision check

### DIFF
--- a/account_invoice_en16931/models/res_company.py
+++ b/account_invoice_en16931/models/res_company.py
@@ -69,15 +69,6 @@ class ResCompany(models.Model):
                     qty_prec,
                 )
             )
-        disc_prec = dpo.precision_get("Discount")
-        if disc_prec > 2:
-            errors.append(
-                self.env._(
-                    "Discount decimal precision is %s. For EN16931, the maximum "
-                    "value is 2.",
-                    disc_prec,
-                )
-            )
         if errors:
             raise UserError(
                 self.env._(


### PR DESCRIPTION
Fixes #43, reported by @almumu.

`_en16931_checks()` refuses to post any customer invoice when the `Discount` decimal precision is above 2. `decimal.precision` is database-global, so in a multi-company database a single company subject to the reform forces every other company down to 2 decimals on discounts — an accounting-wide change well outside the scope of e-invoicing.

The check does not protect the generated document. The discount *percentage* is never exported; what reaches the XML is BT-147, the line price reduction, as an amount formatted with the **price** precision. `disc_prec` has exactly one consumer in the repository — the `float_compare` in `account_move_line.py` deciding *whether* a line carries a discount — and `disc_fmt`, built in `_prepare_en16931_speedy()`, is never read at all.

For that single use, lowering the precision is counterproductive: at 2 decimals a 0.001 discount compares equal to zero and BT-147 is silently omitted from the document.

If this is protecting an EN16931 or AFNOR rule we missed, turning it into a non-blocking warning would already remove the multi-company side effect — happy to send that instead.
