### PR TITLE
[18.0][FIX] account_invoice_en16931: only check the EN16931 config of issuing companies

### DIFF
--- a/account_invoice_en16931/models/account_move.py
+++ b/account_invoice_en16931/models/account_move.py
@@ -226,7 +226,8 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         for move in self.filtered(lambda x: x.is_sale_document()):
-            move.company_id._en16931_checks()
+            if move.company_id.en16931_issuer:
+                move.company_id._en16931_checks()
             errors = []
             if not move.company_id.no_vat_taxes:
                 for line in move.invoice_line_ids.filtered(

--- a/account_invoice_en16931/models/res_company.py
+++ b/account_invoice_en16931/models/res_company.py
@@ -19,6 +19,14 @@ class ResCompany(models.Model):
         default="facturx",
         string="Default PDF Invoice Generation",
     )
+    en16931_issuer = fields.Boolean(
+        string="Issues EN16931 e-Invoices",
+        help="Check the EN16931 configuration of this company when a customer "
+        "invoice is posted. Leave unchecked for companies that never emit an "
+        "EN16931 document: their tax configuration is then only checked when "
+        "such a document is actually generated. Localisation modules may set "
+        "this field for the companies they cover.",
+    )
     no_vat_taxes = fields.Boolean(
         compute="_compute_no_vat_taxes", string="Company has no VAT Taxes"
     )

--- a/account_invoice_en16931/wizards/res_config_settings.py
+++ b/account_invoice_en16931/wizards/res_config_settings.py
@@ -11,6 +11,7 @@ class ResConfigSettings(models.TransientModel):
     en16931_default_pdf_invoice = fields.Selection(
         related="company_id.en16931_default_pdf_invoice", readonly=False
     )
+    en16931_issuer = fields.Boolean(related="company_id.en16931_issuer", readonly=False)
     no_vat_taxes = fields.Boolean(related="company_id.no_vat_taxes")
     no_vat_taxes_vatex_id = fields.Many2one(
         related="company_id.no_vat_taxes_vatex_id", readonly=False
@@ -22,3 +23,23 @@ class ResConfigSettings(models.TransientModel):
         string="Raise Error if Saxon Validation Fails",
         config_parameter="en16931.saxon_validation_blocking",
     )
+
+    def button_en16931_checks(self):
+        """Run the EN16931 configuration checks of the current company on demand.
+
+        _en16931_checks() raises a UserError listing what is wrong, so reaching
+        the end means the company is properly configured.
+        """
+        self.ensure_one()
+        self.company_id._en16931_checks()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "success",
+                "message": self.env._(
+                    "The EN16931 configuration of company %s is valid.",
+                    self.company_id.display_name,
+                ),
+            },
+        }

--- a/account_invoice_en16931/wizards/res_config_settings_view.xml
+++ b/account_invoice_en16931/wizards/res_config_settings_view.xml
@@ -15,6 +15,21 @@
                         <field name="en16931_default_pdf_invoice" class="w-100" />
                     </setting>
                     <setting
+                        id="en16931_issuer"
+                        help="When enabled, the EN16931 configuration of this company is checked every time a customer invoice is posted. Whether it is enabled or not, the same checks always run when an EN16931 document is generated."
+                    >
+                        <field name="en16931_issuer" />
+                        <div class="mt8">
+                            <button
+                                name="button_en16931_checks"
+                                type="object"
+                                string="Check Configuration"
+                                class="btn-link"
+                                icon="fa-check"
+                            />
+                        </div>
+                    </setting>
+                    <setting
                         id="saxon_server_url"
                         help="The default value for the Saxon Server URL is http://localhost:5000/transform If you need to use another URL, you can enter it below."
                     >


### PR DESCRIPTION
Fixes #42, reported by @almumu.

`_post()` runs `company_id._en16931_checks()` for every sale document, with no condition. In a multi-company database where a single company is subject to the French reform, installing the module makes **all** the other companies unable to post customer invoices until their own taxes are UNECE-coded — including companies in other countries that will never emit an EN16931 document.

**Measured on a clean 19.0 database**, whole stack installed, same command before and after: the unconditional check raises `The following errors have been detected in company ... that block EN16931 e-invoicing` in **390 standard Odoo tests** (account 287, sale 45, account_edi_ubl_cii 18, account_payment 8) — all of them tests that create their own company and post an invoice on it. The full run goes from `41 failed, 418 errors of 3902 tests` to `39 failed, 51 errors of 3976 tests`.

Two occurrences survive, in `account.tests.test_audit_trail`: those reach the check through the *generation* path, which this patch deliberately leaves unconditional.

The document itself is never at risk: `_en16931_checks()` is also called from `_en16931_checks_upon_invoice_generation()`, so a company with an incomplete configuration still cannot *generate* an EN16931 document. The call in `_post()` only anticipates that same error at posting time.

This implements option 2 of the issue rather than option 1 (removing the call), so that nothing is lost for the companies that do issue:

* `res.company.en16931_issuer`, unset by default, which localisation modules can set for the companies they cover;
* the `_post()` check is gated on it;
* the configuration stays verifiable at any time from the accounting settings, through a **Check Configuration** button running the same checks on demand.

Tell us if you'd rather have option 1 — a two-line diff — or a different default for the new field, and we'll adjust.
