### PR TITLE
[18.0][FIX] l10n_fr_einvoicing: add a compute field to help displaying or not the closed entity warning

### DIFF
--- a/l10n_fr_einvoicing/models/res_partner.py
+++ b/l10n_fr_einvoicing/models/res_partner.py
@@ -106,6 +106,9 @@ class ResPartner(models.Model):
     fr_directory_show_warning_missing_siren = fields.Boolean(
         compute="_compute_fr_directory_show_warning_missing_siren"
     )
+    fr_directory_show_warning_closed = fields.Boolean(
+        compute="_compute_fr_directory_show_warning_closed",
+    )
 
     @api.depends("type", "parent_id", "fr_directory_entity_type", "fr_directory_closed")
     def _compute_fr_directory_line_show(self):
@@ -119,6 +122,13 @@ class ResPartner(models.Model):
             ):
                 show = True
             partner.fr_directory_line_show = show
+
+    @api.depends("fr_directory_closed", "parent_id.fr_directory_closed")
+    def _compute_fr_directory_show_warning_closed(self):
+        for partner in self:
+            partner.fr_directory_show_warning_closed = bool(
+                partner.fr_directory_closed or partner.parent_id.fr_directory_closed
+            )
 
     @api.depends("fr_directory_line_ids")
     def _compute_fr_directory_line_active_count(self):

--- a/l10n_fr_einvoicing/models/res_partner.py
+++ b/l10n_fr_einvoicing/models/res_partner.py
@@ -108,6 +108,7 @@ class ResPartner(models.Model):
     )
     fr_directory_show_warning_closed = fields.Boolean(
         related="commercial_partner_id.fr_directory_closed",
+        string="Display warning for closed entity",
     )
 
     @api.depends("type", "parent_id", "fr_directory_entity_type", "fr_directory_closed")

--- a/l10n_fr_einvoicing/models/res_partner.py
+++ b/l10n_fr_einvoicing/models/res_partner.py
@@ -107,7 +107,7 @@ class ResPartner(models.Model):
         compute="_compute_fr_directory_show_warning_missing_siren"
     )
     fr_directory_show_warning_closed = fields.Boolean(
-        compute="_compute_fr_directory_show_warning_closed",
+        related="commercial_partner_id.fr_directory_closed",
     )
 
     @api.depends("type", "parent_id", "fr_directory_entity_type", "fr_directory_closed")
@@ -122,13 +122,6 @@ class ResPartner(models.Model):
             ):
                 show = True
             partner.fr_directory_line_show = show
-
-    @api.depends("fr_directory_closed", "parent_id.fr_directory_closed")
-    def _compute_fr_directory_show_warning_closed(self):
-        for partner in self:
-            partner.fr_directory_show_warning_closed = bool(
-                partner.fr_directory_closed or partner.parent_id.fr_directory_closed
-            )
 
     @api.depends("fr_directory_line_ids")
     def _compute_fr_directory_line_active_count(self):

--- a/l10n_fr_einvoicing/views/res_partner.xml
+++ b/l10n_fr_einvoicing/views/res_partner.xml
@@ -99,7 +99,7 @@
             <div name="warning_company" position="after">
                 <div
                     name="fr_directory_closed"
-                    invisible="not fr_directory_closed and not (parent_id and parent_id.fr_directory_closed)"
+                    invisible="not fr_directory_show_warning_closed"
                     class="alert alert-warning"
                     role="alert"
                 >According to the directory, this entity is <strong>closed</strong>.


### PR DESCRIPTION


The condition on parent_id.fr_directory_closed for the invisible attribute in the res.partner view doesn't work probably because the ORM does not load parent_id.fr_directory_closed client side.
Therefore the warning on closed entities is shown on contacts belonging to non-french entities.
This fix creates a computed field to put the logic server-side.