### PR TITLE
[16.0][FIX] finish the 16.0 backport: view modifiers and manifest version

### DIFF
--- a/account_invoice_en16931/views/account_move.xml
+++ b/account_invoice_en16931/views/account_move.xml
@@ -47,7 +47,7 @@
                     name="%(account_invoice_en16931_action)s"
                     string="Generate eInvoice"
                     type="action"
-                    invisible="move_type not in ('out_invoice', 'out_refund') or state == 'cancel'"
+                    attrs="{'invisible': ['|', ('move_type', 'not in', ('out_invoice', 'out_refund')), ('state', '=', 'cancel')]}"
                 />
             </field>
             -->

--- a/l10n_fr_einvoicing/views/res_partner.xml
+++ b/l10n_fr_einvoicing/views/res_partner.xml
@@ -94,7 +94,7 @@
             </xpath>
             <!--
                                   <div name="button_box" position="inside">
-                                          <button name="%(l10n_fr_einvoicing.fr_directory_line_action)d" context="{'search_default_partner_id': id, 'search_default_active': True}" class="oe_stat_button" type="action" icon="fa-newspaper-o" invisible="not fr_directory_line_show">
+                                          <button name="%(l10n_fr_einvoicing.fr_directory_line_action)d" context="{'search_default_partner_id': id, 'search_default_active': True}" class="oe_stat_button" type="action" icon="fa-newspaper-o" attrs="{'invisible': [('fr_directory_line_show', '=', False)]}">
                                                   <field string="Active Directory Lines" name="fr_directory_line_active_count" widget="statinfo" />
                                           </button>
         </div> -->

--- a/l10n_fr_einvoicing_directory_import/__manifest__.py
+++ b/l10n_fr_einvoicing_directory_import/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "France eInvoicing Directory Import/Export (CSV)",
-    "version": "18.0.1.0.0",
+    "version": "16.0.1.0.0",
     "category": "Accounting/Localizations/EDI",
     "summary": "Maintain fr.directory.line manually via CSV export/import "
     "when the AFNOR directory API is not available",

--- a/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
+++ b/l10n_fr_einvoicing_directory_import/wizards/fr_directory_csv_wizard_views.xml
@@ -69,10 +69,10 @@
                     name="result_summary"
                     readonly="1"
                     nolabel="1"
-                    invisible="not result_summary"
+                    attrs="{'invisible': [('result_summary', '=', False)]}"
                 />
                 <field name="result_partner_ids" invisible="1" />
-                <div class="mt-2" invisible="not result_partner_ids">
+                <div class="mt-2" attrs="{'invisible': [('result_partner_ids', '=', [])]}">
                     <button
                         name="action_view_partners"
                         type="object"


### PR DESCRIPTION
Two leftovers from the backport, both blocking or misleading on 16.0.

1. Four view modifiers still use the Odoo 17+ syntax. In 16.0 a node-level `invisible` is evaluated against the context only, so an expression that references a field raises NameError and the module fails to install:

    ValueError: <class 'NameError'>: "name 'result_summary' is not defined"
    while evaluating 'not result_summary'

The two remaining `invisible="not context.get(...)"` in fr_einvoicing_event.xml are left untouched: those do resolve against the context in 16.0.

2. l10n_fr_einvoicing_directory_import still declares version 18.0.1.0.0, while the other nine modules are on 16.0.1.0.0.

Tested on a clean 16.0 community database: the eight installable modules install without error (81 modules loaded) and the test suite passes (15 tests, 0 failed, 0 errors).

Partially addresses #55: this PR covers the two mechanical leftovers (the view modifiers and the manifest version). The third point of that issue — the missing `tests/` directory of `l10n_fr_einvoicing_directory_import`, 34 tests that exist on the PR #33 branch but not here — is **not** covered.
