### PR TITLE
[FIX] l10n_fr_einvoicing: add missing res.partner.is_france_country

### DIFF
--- a/l10n_fr_einvoicing/models/res_partner.py
+++ b/l10n_fr_einvoicing/models/res_partner.py
@@ -110,6 +110,10 @@ class ResPartner(models.Model):
         related="commercial_partner_id.fr_directory_closed",
         string="Show warning if entity closed",
     )
+    is_france_country = fields.Boolean(
+        compute="_compute_is_france_country",
+        string="Is Part of DOM-TOM",
+    )
 
     @api.depends("type", "parent_id", "fr_directory_entity_type", "fr_directory_closed")
     def _compute_fr_directory_line_show(self):
@@ -168,6 +172,12 @@ class ResPartner(models.Model):
                     )
                 )
             partner.fr_directory_entity_changed_warning = warn_msg
+
+    @api.depends("country_id")
+    def _compute_is_france_country(self):
+        france_codes = self.env["res.company"]._get_france_country_codes()
+        for partner in self:
+            partner.is_france_country = partner.country_id.code in france_codes
 
     @api.depends("vat", "siren", "is_company", "parent_id", "is_france_country")
     def _compute_fr_directory_show_warning_missing_siren(self):

--- a/l10n_fr_einvoicing/views/res_partner.xml
+++ b/l10n_fr_einvoicing/views/res_partner.xml
@@ -56,6 +56,7 @@
                         </button>
                     </div>
                     <field name="fr_directory_line_show" invisible="1" />
+                    <field name="is_france_country" invisible="1" />
                     <field name="fr_directory_entity_changed_warning" invisible="1" />
                     <field
                         name="fr_directory_show_warning_missing_siren"


### PR DESCRIPTION
## What

Module fails to install: `_compute_fr_directory_show_warning_missing_siren`
depends on `is_france_country`, a field that only ever existed on
`res.company` (core `l10n_fr`), not on `res.partner`.

## Contents

- Add `is_france_country` compute field on `res.partner`, derived
  from the partner's own `country_id` (not `company_id`, which is
  record ownership, not the partner's location)
- Reuses `res.company._get_france_country_codes()` for the country
  code list