### PR TITLE
[16][FIX] l10n_fr_einvoicing_sale: Add rights on einvoicing events for salesman to allow him to read sale order invoice

### DIFF
--- a/l10n_fr_einvoicing_sale/__manifest__.py
+++ b/l10n_fr_einvoicing_sale/__manifest__.py
@@ -16,6 +16,7 @@
         "sale_commercial_partner",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/ir_actions_server.xml",
         "views/sale_order.xml",
         "wizards/res_config_settings_view.xml",

--- a/l10n_fr_einvoicing_sale/security/ir.model.access.csv
+++ b/l10n_fr_einvoicing_sale/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_fr_einvoicing_event_read_sale,Read access on fr.einvoicing.event for salesman,l10n_fr_einvoicing.model_fr_einvoicing_event,sales_team.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
Without this access, salesman have an error when navigating from a sale order to an invoice (if the user don't have any invoicing rights)